### PR TITLE
fix/environ_key_error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "service_now_api_sdk"
-version = "0.0.23"
+version = "0.0.24"
 description = "Service Now API SDK is used to facilitate integrations, automations and also code reuse"
 authors = ["stone_people_analytics <systems-techpeople@stone.com.br>"]
 maintainers = [

--- a/service_now_api_sdk/settings.py
+++ b/service_now_api_sdk/settings.py
@@ -1,6 +1,6 @@
 import os
 
-SERVICENOW_URL = os.environ["SERVICENOW_URL"]
+SERVICENOW_URL = os.environ.get("SERVICENOW_URL")
 SERVICENOW_API_TOKEN = os.environ.get("SERVICENOW_API_TOKEN")
 
 SERVICENOW_API_USER = os.environ.get("SERVICENOW_API_USER")


### PR DESCRIPTION
The `os.environ['SERVICENOW_URL']` when no SERVICENOW_URL is declared was causing a KeyError, to avoid this, returns `default_value` if the key doesn't exist with `os.environ.get('SERVICENOW_URL')`.