### PR TITLE
chore: add a controlled requests getting next data from api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [tool.poetry]
 name = "service_now_api_sdk"
-version = "0.0.24"
+version = "0.0.25"
 description = "Service Now API SDK is used to facilitate integrations, automations and also code reuse"
 authors = ["stone_people_analytics <systems-techpeople@stone.com.br>"]
 maintainers = [
     "guilherme_lsilva <manager.guilherme.silva@gmail.com>",
     "diogo56 <diogo.amorim2001@gmail.com>",
+    "root-who <joaopaulo_gonzaga@outlook.com>",
 ]
 readme = "README.md"
 license = "MIT"

--- a/service_now_api_sdk/sdk/servicenow/table/client.py
+++ b/service_now_api_sdk/sdk/servicenow/table/client.py
@@ -239,7 +239,7 @@ class Records(BaseTableAPI):
 
         return params
 
-    def __request_helper(self, next_link="", retries=5):
+    def __request_helper(self, next_link="", retries=5) -> str:
         try:
             result = None
             params = self._get_params()
@@ -277,7 +277,7 @@ class Records(BaseTableAPI):
             else:
                 raise RecordRetriesException(e)
 
-    def __request_helper_without_next_link(self, retries=5) -> list[dict]:
+    def __request_helper_without_next_link(self, retries=5) -> int:
         try:
             params = self._get_params()
             if not self.sysparm_offset:

--- a/service_now_api_sdk/sdk/servicenow/table/client.py
+++ b/service_now_api_sdk/sdk/servicenow/table/client.py
@@ -332,6 +332,7 @@ class Records(BaseTableAPI):
         )
         return self
 
+    @property
     def next(self):
         """[summary]
 


### PR DESCRIPTION
This pull request refactors and enhances mainly the `Records` classe in the ServiceNow Table API client. 
The main focus is on improving parameter handling, restructuring instance variables, and optimizing how paginated data is fetched and stored. 

**Refactoring of class attributes and initialization:**

* Moved class-level default attributes in `BaseTableAPI` and `Records` to instance-level initialization within `__init__`, ensuring each instance has its own configuration and avoiding shared mutable state. [[1]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6L14-R21) [[2]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6L116-R123)

**Enhancements to parameter handling:**

* Added support for the `sysparm_count` parameter, including a new `count()` method and logic in `_get_params` to include this parameter when set. [[1]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6L116-R123) [[2]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6R186-R197) [[3]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6L220-R306)

**Improvements to data fetching and pagination:**

* Refactored the internal request helper methods to use instance-level `self.data` for accumulating results, streamlined the pagination logic, and improved retry handling. The `all()` and `get()` methods now use these helpers to fetch all pages of data efficiently. [[1]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6L220-R306) [[2]](diffhunk://#diff-5ccad6008646a13cfe6d9f2e6e7414576bff1661929ecf8a9872eb260c9775b6L320-R366)
* Simplified and clarified the way paginated requests are handled, distinguishing between cases where pagination headers are suppressed and when they are not.

These changes collectively make the ServiceNow Table API client more robust, easier to maintain, and ready for additional features.

Code exemple using the property next in the class `Records`:

```
table = "x_stps2_services_chair"
record = Records(table)
record.limit(5000)
record.suppress_pagination_header(True)
while True:
    total.extend(record.next.data)
    if record.total_registers_sequence_request == 0:
        break

total = []
record.suppress_pagination_header(False)
while True:
    total.extend(record.next.data)
    if record.next_link_sequence_request is None:
        break
```